### PR TITLE
022623b | Router Change Progress Bar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import "../styles/globals.css";
+import "nprogress/nprogress.css";
 import NavBar from "../components/common/NavBar";
 import Providers from "./providers";
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,11 +1,15 @@
 "use client";
+import { useCallback } from "react";
 import { HydrationProvider } from "../components/common/HydrationProvider";
 import { SessionProvider } from "next-auth/react";
+import { RouterChangeProviderWrapper } from "../components/common/RouterChangeProviderWrapper";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
-      <HydrationProvider>{children}</HydrationProvider>
+      <RouterChangeProviderWrapper>
+        <HydrationProvider>{children}</HydrationProvider>
+      </RouterChangeProviderWrapper>
     </SessionProvider>
   );
 }

--- a/components/animev3/layoutSelector/HeaderSelector.tsx
+++ b/components/animev3/layoutSelector/HeaderSelector.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useContext } from "react";
 import { Season, getSeasonFromEnum } from "../helpers";
+import { RouterChangeContext } from "../../common/RouterChangeProvider";
 
 interface PageProps {
   byPopularity: any;
@@ -19,6 +20,7 @@ export function HeaderSelector({
   setByPopularity,
 }: PageProps) {
   const router = useRouter();
+  const startChange = useContext(RouterChangeContext);
 
   const displaySeasonText = {
     0: {
@@ -39,41 +41,49 @@ export function HeaderSelector({
     },
   };
 
+  const routerPushWrapper = (url: string) => {
+    const { pathname, search, hash } = window.location;
+    if (url !== pathname + search + hash) {
+      startChange();
+    }
+    router.push(url);
+  };
+
   const onClickHandler = (event: any) => {
     let values = event.currentTarget?.value?.split(" ");
     if (year) {
       if (parseInt(values[0]) === Season.WINTER) {
         if (event.currentTarget.id === "season-back") {
           const prevYear = parseInt(year) - 1;
-          router.push(`/anime/${prevYear}/fall`);
+          routerPushWrapper(`/anime/${prevYear}/fall`);
         }
         if (event.currentTarget.id === "season-forward") {
-          router.push(`/anime/${year}/spring`);
+          routerPushWrapper(`/anime/${year}/spring`);
         }
       }
       if (parseInt(values[0]) === Season.SPRING) {
         if (event.currentTarget.id === "season-back") {
-          router.push(`/anime/${year}/winter`);
+          routerPushWrapper(`/anime/${year}/winter`);
         }
         if (event.currentTarget.id === "season-forward") {
-          router.push(`/anime/${year}/summer`);
+          routerPushWrapper(`/anime/${year}/summer`);
         }
       }
       if (parseInt(values[0]) === Season.SUMMER) {
         if (event.currentTarget.id === "season-back") {
-          router.push(`/anime/${year}/spring`);
+          routerPushWrapper(`/anime/${year}/spring`);
         }
         if (event.currentTarget.id === "season-forward") {
-          router.push(`/anime/${year}/fall`);
+          routerPushWrapper(`/anime/${year}/fall`);
         }
       }
       if (parseInt(values[0]) === Season.FALL) {
         if (event.currentTarget.id === "season-back") {
-          router.push(`/anime/${year}/summer`);
+          routerPushWrapper(`/anime/${year}/summer`);
         }
         if (event.currentTarget.id === "season-forward") {
           const nextYear = parseInt(year) + 1;
-          router.push(`/anime/${nextYear}/winter`);
+          routerPushWrapper(`/anime/${nextYear}/winter`);
         }
       }
     }

--- a/components/common/AnimeBar.tsx
+++ b/components/common/AnimeBar.tsx
@@ -1,9 +1,9 @@
 "use client";
 import { useContext } from "react";
 import { usePathname } from "next/navigation";
-import Link from "next/link";
 import { HydrationContext } from "./HydrationProvider";
 import { getCurrentSeasonPath } from "../animev3/helpers";
+import { LinkRouterWrapper } from "./LinkRouterWrapper";
 
 const getCurrentYear = (shifted: Boolean = false) => {
   const dateObject = new Date();
@@ -27,7 +27,7 @@ export function AnimeBar() {
 
   return (
     <>
-      <Link
+      <LinkRouterWrapper
         href={`/anime/${getCurrentYear(true)}/${getCurrentSeasonPath(
           null,
           true
@@ -40,9 +40,9 @@ export function AnimeBar() {
           "
       >
         <p>カイル</p>
-      </Link>
+      </LinkRouterWrapper>
       {hydrated && isAnimeRoute && (
-        <Link
+        <LinkRouterWrapper
           href={`/topanime`}
           className="
             block
@@ -52,7 +52,7 @@ export function AnimeBar() {
           "
         >
           <p>Top Anime</p>
-        </Link>
+        </LinkRouterWrapper>
       )}
     </>
   );

--- a/components/common/LinkRouterWrapper.tsx
+++ b/components/common/LinkRouterWrapper.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import React, { useContext } from "react";
+import Link from "next/link";
+import { RouterChangeContext } from "./RouterChangeProvider";
+
+export const LinkRouterWrapper = ({
+  href,
+  className,
+  children,
+}: React.PropsWithChildren<{ href: string; className: string }>) => {
+  const startChange = useContext(RouterChangeContext);
+  const useLink = href && href.startsWith("/");
+
+  if (useLink)
+    return (
+      <Link
+        href={href}
+        onClick={() => {
+          const { pathname, search, hash } = window.location;
+          if (href !== pathname + search + hash) {
+            startChange();
+          }
+        }}
+        className={className}
+      >
+        {children}
+      </Link>
+    );
+  return (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  );
+};

--- a/components/common/LogInBox.tsx
+++ b/components/common/LogInBox.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useSession, signOut } from "next-auth/react";
 // import { unstable_getServerSession } from "next-auth/next";
 // import { authOptions } from "../../server/auth";
+import { LinkRouterWrapper } from "./LinkRouterWrapper";
 
 export default function LoginBox() {
   // const session = await unstable_getServerSession(authOptions);
@@ -18,7 +19,7 @@ export default function LoginBox() {
   if (session) {
     return (
       <div className="flex justify-items-center">
-        <Link
+        <LinkRouterWrapper
           href="/mylist"
           className="
             block
@@ -28,7 +29,7 @@ export default function LoginBox() {
           "
         >
           <p>My List</p>
-        </Link>
+        </LinkRouterWrapper>
         <button
           className="
             p-5
@@ -45,7 +46,7 @@ export default function LoginBox() {
 
   return (
     <div className="flex justify-items-center">
-      <Link
+      <LinkRouterWrapper
         href="/auth"
         className="
             block
@@ -55,7 +56,7 @@ export default function LoginBox() {
           "
       >
         <p>LogIn</p>
-      </Link>
+      </LinkRouterWrapper>
     </div>
   );
 }

--- a/components/common/NavBar.tsx
+++ b/components/common/NavBar.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 // import { authOptions } from "../../server/auth";
 import LoginBox from "./LogInBox";
 import { AnimeBar } from "./AnimeBar";
+import { LinkRouterWrapper } from "./LinkRouterWrapper";
 
 const getCurrentYear = (shifted: Boolean = false) => {
   const dateObject = new Date();
@@ -32,7 +33,7 @@ export default function NavBar() {
         >
           <p>Kyle</p>
         </div>
-        <Link
+        <LinkRouterWrapper
           href="/"
           className="
             block
@@ -42,7 +43,7 @@ export default function NavBar() {
           "
         >
           <p>Home</p>
-        </Link>
+        </LinkRouterWrapper>
         <AnimeBar />
       </div>
       <LoginBox />

--- a/components/common/RouterChangeProvider.tsx
+++ b/components/common/RouterChangeProvider.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+const RouterChangeContext = createContext(() => {});
+
+const RouterChangeProvider = ({
+  onStart,
+  onComplete,
+  children,
+}: {
+  onStart?: () => void;
+  onComplete?: () => void;
+  children: React.ReactNode;
+}) => {
+  const [isChanging, setIsChanging] = useState(false);
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  useEffect(() => setIsChanging(false), [pathname, searchParams]);
+
+  useEffect(() => {
+    if (isChanging) {
+      console.log("Route Change Start", onStart);
+      /* @ts-ignore */
+      onStart();
+    } else {
+      console.log("Route Change Complete", onComplete);
+      /* @ts-ignore */
+      onComplete();
+    }
+  }, [isChanging]);
+
+  return (
+    <RouterChangeContext.Provider value={() => setIsChanging(true)}>
+      {children}
+    </RouterChangeContext.Provider>
+  );
+};
+
+export { RouterChangeProvider, RouterChangeContext };

--- a/components/common/RouterChangeProviderWrapper.tsx
+++ b/components/common/RouterChangeProviderWrapper.tsx
@@ -1,0 +1,15 @@
+import { useCallback } from "react";
+import { RouterChangeProvider } from "./RouterChangeProvider";
+import NProgress from "nprogress";
+
+export const RouterChangeProviderWrapper = ({
+  children,
+}: React.PropsWithChildren) => {
+  const onStart = useCallback(() => NProgress.start(), []);
+  const onComplete = useCallback(() => NProgress.done(), []);
+  return (
+    <RouterChangeProvider onStart={onStart} onComplete={onComplete}>
+      {children}
+    </RouterChangeProvider>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,12 +26,14 @@
         "mongoose": "^6.8.1",
         "next": "13.1.6",
         "next-auth": "^4.18.7",
+        "nprogress": "^0.2.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "swr": "^2.0.0",
         "typescript": "4.8.4"
       },
       "devDependencies": {
+        "@types/nprogress": "^0.2.0",
         "autoprefixer": "^10.4.13",
         "critters": "^0.0.16",
         "postcss": "^8.4.18",
@@ -1988,6 +1990,12 @@
         "@types/node": "*",
         "form-data": "^3.0.0"
       }
+    },
+    "node_modules/@types/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-1cYJrqq9GezNFPsWTZpFut/d4CjpZqA0vhqDUPFWYKF1oIyBz5qnoYMzR+0C/T96t3ebLAC1SSnwrVOm5/j74A==",
+      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -5071,6 +5079,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -8188,6 +8201,12 @@
         "form-data": "^3.0.0"
       }
     },
+    "@types/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-1cYJrqq9GezNFPsWTZpFut/d4CjpZqA0vhqDUPFWYKF1oIyBz5qnoYMzR+0C/T96t3ebLAC1SSnwrVOm5/j74A==",
+      "dev": true
+    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -10351,6 +10370,11 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true
+    },
+    "nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
     },
     "nth-check": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,14 @@
     "mongoose": "^6.8.1",
     "next": "13.1.6",
     "next-auth": "^4.18.7",
+    "nprogress": "^0.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "swr": "^2.0.0",
     "typescript": "4.8.4"
   },
   "devDependencies": {
+    "@types/nprogress": "^0.2.0",
     "autoprefixer": "^10.4.13",
     "critters": "^0.0.16",
     "postcss": "^8.4.18",


### PR DESCRIPTION
# Use router change progress bar
- Nextjs13 removed the router events api for the app directory due to react 18 concurrency.
  - In order to use a progress bar on router change, I had to create my own api for router events.
  - By using my own mimicked router events api, I am able to display a progress bar on router change events 
  - Normally react 18 streaming and suspense handles route change transitions pretty well but for some routes, its still nice to have manual router event transistion for better perceived reactivity on route changes.